### PR TITLE
Fix Java build

### DIFF
--- a/labs/08_tools.md
+++ b/labs/08_tools.md
@@ -54,7 +54,7 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {

--- a/labs/08_tools.md
+++ b/labs/08_tools.md
@@ -25,11 +25,11 @@ Add a JDK:
 
 1. Go to Manage Jenkins > Global Tool Configuration
 2. Under JDK click `Add JDK`
-3. Under name enter `jdk8`
+3. Under name enter `jdk11`
 4. Check `Install automatically`
 5. Under `Add Installer` select `Extract *.zip/*.tar.gz`
-  * Under `Download URL for binary archive` enter: "https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz"
-  * Under `Subdirectory of extracted archive` enter: "java-se-8u41-ri"
+  * Under `Download URL for binary archive` enter: "https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz"
+  * Under `Subdirectory of extracted archive` enter: "jdk-11"
 6. At the bottom of the page click `Apply`
 
 Add Maven:

--- a/labs/09_artifacts.md
+++ b/labs/09_artifacts.md
@@ -30,13 +30,13 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 archiveArtifacts 'target/*.?ar'
                 junit 'target/**/*.xml'  // Requires JUnit plugin
             }

--- a/labs/10_failures.md
+++ b/labs/10_failures.md
@@ -30,7 +30,7 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {

--- a/labs/10_failures.md
+++ b/labs/10_failures.md
@@ -36,7 +36,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 archiveArtifacts 'target/*.?ar'
             }
             post {

--- a/labs/11_shared_libs.md
+++ b/labs/11_shared_libs.md
@@ -64,7 +64,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 archiveArtifacts 'target/*.?ar'
             }
             post {

--- a/labs/11_shared_libs.md
+++ b/labs/11_shared_libs.md
@@ -58,7 +58,7 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {

--- a/labs/12_credentials.md
+++ b/labs/12_credentials.md
@@ -38,7 +38,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 sh "mvn -s '${M2_SETTINGS}' -B deploy:deploy-file -DrepositoryId='puzzle-releases' -Durl='${REPO_URL}' -DgroupId='com.puzzleitc.jenkins-techlab' -DartifactId='${ARTIFACT}' -Dversion='1.0' -Dpackaging='jar' -Dfile=`echo target/*.jar`"
                 sshagent(['testserver']) {  // SSH Agent Plugin
                     sh "ls -l target"

--- a/labs/12_credentials.md
+++ b/labs/12_credentials.md
@@ -32,7 +32,7 @@ pipeline {
         REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {

--- a/labs/13_stages_locks_milestones.md
+++ b/labs/13_stages_locks_milestones.md
@@ -32,7 +32,7 @@ pipeline {
         REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {

--- a/labs/13_stages_locks_milestones.md
+++ b/labs/13_stages_locks_milestones.md
@@ -46,7 +46,7 @@ pipeline {
             steps {
                 // Only one build is allowed to use test resources, newest builds run first
                 lock(resource: 'myResource', inversePrecedence: true) {  // Lockable Resources Plugin
-                    sh 'mvn -B -V -U -e verify -Dsurefire.useFile=false'
+                    sh 'mvn -B -V -U -e verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                     milestone(20)  // Abort all older builds that didn't get here
                 }
             }

--- a/labs/scripted/08_scripted_tools.md
+++ b/labs/scripted/08_scripted_tools.md
@@ -13,7 +13,7 @@ timestamps() {
     timeout(time: 10, unit: 'MINUTES') {
         node { // with hosted env use node(env.JOB_NAME.split('/')[0])
             stage('Greeting') {
-                withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     sh "java -version"
                     sh "mvn --version"
                 }

--- a/labs/scripted/09_scripted_artifacts.md
+++ b/labs/scripted/09_scripted_artifacts.md
@@ -16,7 +16,7 @@ timestamps() {
             stage('Build') {
                 withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     checkout scm
-                    sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                    sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                     archiveArtifacts 'target/*.?ar'
                     junit 'target/**/*.xml'  // Requires JUnit plugin
                 }

--- a/labs/scripted/09_scripted_artifacts.md
+++ b/labs/scripted/09_scripted_artifacts.md
@@ -14,7 +14,7 @@ timestamps() {
     timeout(time: 10, unit: 'MINUTES') {
         node { // with hosted env use node(env.JOB_NAME.split('/')[0])
             stage('Build') {
-                withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     checkout scm
                     sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
                     archiveArtifacts 'target/*.?ar'

--- a/labs/scripted/10_scripted_failures.md
+++ b/labs/scripted/10_scripted_failures.md
@@ -15,7 +15,7 @@ try {
                     try {
                         withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                             checkout scm
-                            sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                            sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                             archiveArtifacts 'target/*.?ar'
                         }
                     } finally {

--- a/labs/scripted/10_scripted_failures.md
+++ b/labs/scripted/10_scripted_failures.md
@@ -13,7 +13,7 @@ try {
             node { // with hosted env use node(env.JOB_NAME.split('/')[0])
                 stage('Build') {
                     try {
-                        withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                        withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                             checkout scm
                             sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
                             archiveArtifacts 'target/*.?ar'

--- a/labs/scripted/12_scripted_credentials.md
+++ b/labs/scripted/12_scripted_credentials.md
@@ -17,7 +17,7 @@ timestamps() {
         env.REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
         node { // with hosted env use node(env.JOB_NAME.split('/')[0])
             withCredentials([file(credentialsId: 'm2_settings', variable: 'M2_SETTINGS'), usernameColonPassword(credentialsId: 'jenkins-artifactory', variable: 'ARTIFACTORY'), file(credentialsId: 'known_hosts', variable: 'KNOWN_HOSTS')]) {  // Credentials Binding Plugin
-                withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     stage('Build') {
                         checkout scm
                         sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'

--- a/labs/scripted/12_scripted_credentials.md
+++ b/labs/scripted/12_scripted_credentials.md
@@ -20,7 +20,7 @@ timestamps() {
                 withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     stage('Build') {
                         checkout scm
-                        sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                        sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                         sh "mvn -s '${M2_SETTINGS}' -B deploy:deploy-file -DrepositoryId='puzzle-releases' -Durl='${REPO_URL}' -DgroupId='com.puzzleitc.jenkins-techlab' -DartifactId='${ARTIFACT}' -Dversion='1.0' -Dpackaging='jar' -Dfile=`echo target/*.jar`"
                         sshagent(['testserver']) {  // SSH Agent Plugin
                             sh "ls -l target"

--- a/labs/solutions/10_3_failures_solution.md
+++ b/labs/solutions/10_3_failures_solution.md
@@ -27,7 +27,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                withEnv(["JAVA_HOME=${tool 'jdk8_oracle'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -Dmaven.test.failure.ignore=true'
                     archiveArtifacts 'target/*.?ar'
                 }
@@ -78,7 +78,7 @@ try {
             node(env.JOB_NAME.split('/')[0]) {
                 stage('Build') {
                     try {
-                        withEnv(["JAVA_HOME=${tool 'jdk8_oracle'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                        withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                             checkout scm
                             sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -Dmaven.test.failure.ignore=true'
                             archiveArtifacts 'target/*.?ar'


### PR DESCRIPTION
Bump OpenJDK to version 11 [(Newer OpenJDK than v10 includes root ca certs)](https://blogs.oracle.com/jtc/openjdk-10-now-includes-root-ca-certificates)
Disable class path URL check to avoid surefire crash ([Source](https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class))